### PR TITLE
Fix Header ::before pseudo element, visually hidden text and contact image

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -23,7 +23,7 @@
         <!--Mobile Nav toggle-->
         <button class="hamburger-menu" aria-expanded="false" aria-controls="navbar-menu">
             <span class="visually-hidden">Menu</span>
-            <span aria-hidden="true"></span>
+            <span class="menu-icon" aria-hidden="true"></span>
         </button>
 
         <!--Main Nav-->

--- a/src/blog/another-test-post copy 2.md
+++ b/src/blog/another-test-post copy 2.md
@@ -1,0 +1,13 @@
+---
+pageName: another-test-post-copy-2
+blogTitle: Yet Another Test Post Copy
+titleTag: Yet Yet Another Test Post Copy
+blogDescription: Here is yet yet another test post to make sure that everything is sound and smooth
+author: Joe Mendez's Cousin
+date: 2022-12-16T19:45:03.587Z
+tags:
+  - post
+image: https://images.unsplash.com/photo-1670768563220-c13cfa7e1dbc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&q=80.jpg
+imageAlt: Mountains
+---
+Testing testing 1 2 3

--- a/src/blog/another-test-post copy 3.md
+++ b/src/blog/another-test-post copy 3.md
@@ -1,0 +1,13 @@
+---
+pageName: greg
+blogTitle: Test Post Copy
+titleTag: Another Test Post Copy
+blogDescription: Here is yet another test post to make sure that everything is sound and smooth
+author: A different Joe Mendez
+date: 2022-12-16T19:45:03.587Z
+tags:
+  - post
+image: https://images.unsplash.com/photo-1670768563220-c13cfa7e1dbc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&q=80.jpg
+imageAlt: Mountains
+---
+Testing testing 1 2 3

--- a/src/blog/another-test-post copy.md
+++ b/src/blog/another-test-post copy.md
@@ -1,0 +1,13 @@
+---
+pageName: another-test-post-copy
+blogTitle: Test Post Copy
+titleTag: Another Test Post Copy
+blogDescription: Here is yet another test post to make sure that everything is sound and smooth
+author: A different Joe Mendez
+date: 2022-12-16T19:45:03.587Z
+tags:
+  - post
+image: https://images.unsplash.com/photo-1670768563220-c13cfa7e1dbc?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1000&q=80.jpg
+imageAlt: Mountains
+---
+Testing testing 1 2 3

--- a/src/blog/blog-template.md
+++ b/src/blog/blog-template.md
@@ -9,7 +9,7 @@ date: 2022-12-16T19:40:18.253Z
 tags:
   - post
   - featured
-image: /images/blog/landing.jpg
+image: /assets/images/blog/landing.jpg
 imageAlt: Kitchen
 ---
 His etudes and concertos are performed by the world’s leading pianists, and they are famed for their difficulty. Not to mention the International Chopin Piano Competition, an annual affair in Warsaw that springboards the careers of many famous pianists

--- a/src/css/blog.css
+++ b/src/css/blog.css
@@ -61,6 +61,52 @@
   .blog-link:hover:before {
     opacity: 1;
   }
+  .pagination {
+    padding: .5rem 1.5rem;
+    box-shadow: 0px 20px 39px 0px rgba(0, 0, 0, 0.05);
+    border-radius: 0.25rem;
+    border: 1px solid #ebebeb;
+  }
+  .pagination .pagination-list {
+    display: flex;
+    gap: 1rem;
+    list-style: none;
+    align-items: center;
+  }
+  .pagination .pagination-previous,
+  .pagination .pagination-next {
+    display: flex;
+    align-items: center;
+  }
+  .pagination .pagination-previous.inactive,
+  .pagination .pagination-next.inactive {
+    opacity: 0.6;
+  }
+  .pagination .pagination-previous {
+    padding-right: 0.5rem;
+  }
+  .pagination .pagination-next {
+    padding-left: 0.5rem;
+  }
+  .pagination .pagination-numbers {
+    line-height: normal;
+    padding: 0.125rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+  .pagination .pagination-numbers.active {
+    background: var(--primary);
+  }
+  .pagination .pagination-numbers-link {
+    color: var(--bodyHeader);
+    line-height: normal;
+    text-decoration: none;
+  }
+  .pagination .pagination-controller-link {
+    display: flex;
+    line-height: normal;
+    align-self: center;
+    font-size: 1rem;
+  }
 }
 /*-- -------------------------- -->
 <---           Header           -->

--- a/src/css/blog.less
+++ b/src/css/blog.less
@@ -71,6 +71,52 @@
             }
         }
     }
+    .pagination {
+        padding: .5rem 1.5rem;
+        box-shadow: 0px 20px 39px 0px rgba(0, 0, 0, 0.05);
+        border-radius: 4/16rem;
+        border: 1px solid #ebebeb;
+        .pagination-list {
+            display: flex;
+            gap: 1rem;
+            list-style: none;
+            align-items: center;
+        }
+        .pagination-previous, .pagination-next {
+            display: flex;
+            align-items: center;
+            &.inactive {
+                opacity: 0.6;
+            }
+        }
+        .pagination-previous {
+
+            padding-right: 8/16rem;
+        }
+        .pagination-next {
+
+            padding-left: 8/16rem;
+        }
+        .pagination-numbers {
+            line-height: normal;
+            padding: 2/16rem 8/16rem;
+            border-radius: 4/16rem;
+            &.active {
+                background: var(--primary);
+            }
+        }
+        .pagination-numbers-link {
+            color: var(--bodyHeader);
+            line-height: normal;
+            text-decoration: none;
+        }
+        .pagination-controller-link {
+            display: flex;
+            line-height: normal;
+            align-self: center;
+            font-size: 16/16rem;
+        }
+    }
 }
 
 /*-- -------------------------- -->

--- a/src/css/root.css
+++ b/src/css/root.css
@@ -322,7 +322,7 @@
     height: 0.5rem;
     background: var(--primary);
     opacity: 1;
-    bottom: 5rem;
+    bottom: -0.375rem;
     border-radius: 0.25rem;
     left: -0.375rem;
     right: -0.375rem;

--- a/src/css/root.css
+++ b/src/css/root.css
@@ -266,7 +266,7 @@
     overflow: hidden;
     box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
     background-color: #fff;
-    top: 3.7rem;
+    top: 3.6875rem;
     padding-top: 0;
     height: 0;
     transition: height 0.3s, padding-top 0.3s, top 0.3s;
@@ -440,7 +440,7 @@
     border-radius: 0.1875rem;
     background: var(--primary);
     opacity: 1;
-    bottom: 0.125rem;
+    bottom: -0.375rem;
     z-index: -1;
     left: 0;
     width: 0%;
@@ -457,7 +457,7 @@
     height: 0.375rem;
     background: var(--primary);
     opacity: 1;
-    bottom: 0.125rem;
+    bottom: -0.375rem;
     border-radius: 0.1875rem;
     left: 0rem;
     right: -0.375rem;

--- a/src/css/root.css
+++ b/src/css/root.css
@@ -207,7 +207,16 @@
     transform: translateY(-50%);
     transition: top .3s;
   }
-  #navigation .hamburger-menu span {
+  #navigation .hamburger-menu .visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+  #navigation .hamburger-menu .menu-icon {
     height: 2px;
     width: 1.875rem;
     background-color: #000;
@@ -217,7 +226,7 @@
     transform: translateX(-50%);
     transition: background-color 0.3s;
   }
-  #navigation .hamburger-menu span:before {
+  #navigation .hamburger-menu .menu-icon:before {
     content: '';
     position: absolute;
     display: block;
@@ -229,7 +238,7 @@
     left: 0;
     transition: width .3s, left .3s, top .3s, transform .5s;
   }
-  #navigation .hamburger-menu span:after {
+  #navigation .hamburger-menu .menu-icon:after {
     content: '';
     position: absolute;
     display: block;

--- a/src/css/root.less
+++ b/src/css/root.less
@@ -235,7 +235,17 @@
             transform: translateY(-50%);
             transition: top .3s;
 
-            span {
+            .visually-hidden {
+                clip: rect(0 0 0 0);
+                clip-path: inset(50%);
+                height: 1px;
+                overflow: hidden;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
+            }
+
+            .menu-icon {
                 height: 2px;
                 width: 30/16rem;
                 background-color: #000;

--- a/src/css/root.less
+++ b/src/css/root.less
@@ -372,7 +372,7 @@
                                 height: 8/16rem;
                                 background: var(--primary);
                                 opacity: 1;
-                                bottom: 5/1rem;
+                                bottom: -6/16rem;
                                 border-radius: 4/16rem;
                                 left: -6/16rem;
                                 right: -6/16rem;

--- a/src/css/root.less
+++ b/src/css/root.less
@@ -549,7 +549,7 @@
                             border-radius: 3/16rem;
                             background: var(--primary);
                             opacity: 1;
-                            bottom: 2/16rem;
+                            bottom: -6/16rem;
                             z-index: -1;
                             left: 0;
         
@@ -574,7 +574,7 @@
                                 height: 6/16rem;
                                 background: var(--primary);
                                 opacity: 1;
-                                bottom: 2/16rem;
+                                bottom: -6/16rem;
                                 border-radius: 3/16rem;
                                 left: 0/16rem;
                                 right: -6/16rem;

--- a/src/pages/blog.html
+++ b/src/pages/blog.html
@@ -1,24 +1,28 @@
 ---
-layout: 'base.html'
-description: 'Meta description for the page'
-metaTitle: 'Title that shows up on google searches'
-tagTitle: 'Blog'
-preloadImg: '/images/cabinets2-1920w.webp'
-preloadCSS: '/css/blog.css'
-permalink: 'blog/'
+layout: "base.html"
+description: "Meta description for the page"
+metaTitle: "Title that shows up on google searches"
+tagTitle: "Blog"
+permalink: "{% if pagination.pageNumber === 0 %}blog/{% else %}blog/page-{{ pagination.pageNumber + 1 }}/index.html{% endif %}"
+pagination:
+  data: collections.post
+  size: 2
+  alias: post
+preloadImg: "/images/cabinets2-1920w.webp"
+preloadCSS: "/css/blog.css"
 eleventyNavigation:
-    key: Blog
-    order: 500
+  key: Blog
+  order: 500
 ---
 
-<!-- Enter html code below -->
 <!-- ============================================ -->
 <!--                    LANDING                   -->
 <!-- ============================================ -->
 
 <section id="int-hero">
-    <h1 id="home-h">Blog</h1>
-    {% image './src/images/cabinets2.jpg', 'cabinets', '', 'lazy', '(max-width: 850px) 850px, 1920px'%}
+  <h1 id="home-h">Blog</h1>
+  {% image './src/images/cabinets2.jpg', 'cabinets', '', 'lazy', '(max-width:
+  850px) 850px, 1920px'%}
 </section>
 
 <!-- ============================================ -->
@@ -26,60 +30,110 @@ eleventyNavigation:
 <!-- ============================================ -->
 
 <div class="blog-container main-content-wrapper">
-    <!--Main content -->
-    <div class="main-content">
-        <!-- ============================================ -->
-        <!--                 Blog Articles                -->
-        <!-- ============================================ -->
+  <!--Main content -->
+  <div class="main-content">
+    <!-- ============================================ -->
+    <!--                 Blog Articles                -->
+    <!-- ============================================ -->
 
-        {% if collections.post | length == 0 %}
-            <h1>No Recent Posts</h1>
-        {% endif %}
-        {%- for post in collections.post | reverse -%}
-            <article class="recent-articles">
-                <!--Main Article Image-->
-                <picture class="blog-mainImage">
-                    <img
-                        src="{{ post.data.image }}"
-                        alt="{{ post.data.imageAlt }}"
-                        width="795"
-                        height="400"
-                        decoding="async"
-/>
-                </picture>
-                <!--Article Info-->
-                <div class="article-group">
-                    <div class="blog-authorGroup">
-                        <!--Author Image-->
-                        <picture class="blog-author-img">
-                            <img
+    {% if collections.post | length == 0 %}
+    <h1>No Recent Posts</h1>
+    {% endif %} {%- for post in pagination.items | reverse -%}
+    <article class="recent-articles">
+      <!--Main Article Image-->
+      <picture class="blog-mainImage">
+        <img
+          src="{{ post.data.image }}"
+          alt="{{ post.data.imageAlt }}"
+          width="795"
+          height="400"
+          decoding="async"
+        />
+      </picture>
+      <!--Article Info-->
+      <div class="article-group">
+        <div class="blog-authorGroup">
+          <!--Author Image-->
+          <picture class="blog-author-img">
+            <img
               src="/assets/svgs/profile.svg"
               alt="house"
               width="32"
               height="32"
               decoding="async"
-/>
-                        </picture>
-                        <span class="blog-author">{{ post.data.author }}</span>
-                        <span aria-hidden="true" class="blog-dot"></span>
-                        <!--Blog Date-->
-                        <span class="blog-date">{{ post.date | postDate }}</span>
-                    </div>
-                    <h2 class="blog-h1">
-                        {{ post.data.blogTitle }}
-                    </h2>
-                    <p class="blog-desc">
-                        {{ post.data.blogDescription }}
-                    </p>
-                    <a href="{{ post.url }}" class="blog-link">Continue Reading</a>
-                </div>
-            </article>
+            />
+          </picture>
+          <span class="blog-author">{{ post.data.author }}</span>
+          <span aria-hidden="true" class="blog-dot"></span>
+          <!--Blog Date-->
+          <span class="blog-date">{{ post.date | postDate }}</span>
+        </div>
+        <h2 class="blog-h1">{{ post.data.blogTitle }}</h2>
+        <p class="blog-desc">{{ post.data.blogDescription }}</p>
+        <a href="{{ post.url }}" class="blog-link">Continue Reading</a>
+      </div>
+    </article>
+    {%- endfor -%} 
+    <!-- This won't be rendered if we don't have enough posts to need pagination -->
+    {%- if pagination.href.next or pagination.href.previous -%}
+    <nav class="pagination">
+      <ul class="pagination-list">
+        <!-- If on first page we give it the class of inactive -->
+        <li class="pagination-previous {{ 'inactive' if pagination.pageNumber === 0 }}">
+          <a class="pagination-controller-link" href="{{ pagination.href.previous }}">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-left" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+              <polyline points="15 6 9 12 15 18" />
+            </svg>
+          </a>
+        </li>
+        <!-- Display the number of pages in the blog -->
+        {%- for pageEntry in pagination.pages -%}
+          <!-- Render two next pages if the current page is the first page -->
+          {% if pagination.pageNumber === 0 %}
+            {% if loop.index <= 3 %}
+            <!-- Give class of active if we are in the page the number is representing -->
+            <li class="pagination-numbers {{ 'active' if pagination.pageNumber + 1 === loop.index }}">
+              <a class="pagination-numbers-link" href="{{ pagination.hrefs[loop.index0]}}">{{loop.index}}</a>
+            </li>
+            {%- endif -%}
+          {%- endif -%}
+          <!-- Renders the pages in between -->
+          {% if pagination.pageNumber !== 0 and pagination.pageNumber + 1 !== collections.post.length %}
+            {% if pagination.pageNumber - 1 < loop.index %}
+            <!-- Give class of active if we are in the page the number is representing -->
+            <li class="pagination-numbers {{ 'active' if pagination.pageNumber + 1 === loop.index }}">
+              <a class="pagination-numbers-link" href="{{ pagination.hrefs[loop.index0]}}">{{loop.index}}</a>
+            </li>
+            {%- endif -%}
+          {%- endif -%}
+          <!-- If on last page render the previous 2 pages -->
+          {% if pagination.pageNumber + 1 === collections.post.length %}
+            {% if loop.index >= collections.post.length - 2 %}
+            <!-- Give class of active if we are in the page the number is representing -->
+            <li class="pagination-numbers {{ 'active' if pagination.pageNumber + 1 === loop.index }}">
+              <a class="pagination-numbers-link" href="{{ pagination.hrefs[loop.index0]}}">{{loop.index}}</a>
+            </li>
+            {% endif %}
+          {%- endif -%}
         {%- endfor -%}
-    </div>
+        <!-- If on last page we give it the class of inactive -->
+        <li class="pagination-next {{ 'inactive' if pagination.pageNumber + 1 == collections.post.length }}">
+          <a class="pagination-controller-link" href="{{ pagination.href.next }}">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-right" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+              <polyline points="9 6 15 12 9 18" />
+            </svg>
+          </a>
+        </li>
+      </ul>
+    </nav>
+    {%- endif -%}
+  </div>
 
-    <!-- ============================================ -->
-    <!--                Featured Posts                -->
-    <!-- ============================================ -->
+  <!-- ============================================ -->
+  <!--                Featured Posts                -->
+  <!-- ============================================ -->
 
-    {% include 'featured-post.html' %}
+  {% include 'featured-post.html' %}
 </div>

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -70,7 +70,7 @@ eleventyNavigation:
       <a class="cs-link" href="">2553 Woodbridge Lane, <span class="cs-block">Boston Ware 120</span></a>
 
       <!-- Background Image-->
-      {% image './src/images/skyscraper.jpg', 'building', '', 'lazy'%}
+      {% image './src/images/skyscraper.jpg', 'building', 'cs-bg-picture', 'lazy'%}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What?
- Fixed an overflow issue with the ::before pseudo element on the navbar, on mobile and desktop.
- Fixed text overflowing on the Menu Icon on smallers screens (Tablets and Below).
- Fixed contact image missing a class

## Why?
- These changes make it easier to get started working with the kit.

## How?

### Header
- I changed the bottom value for the ::before pseudo element in the header nav from 2/16rem to -6/16rem on the root.less file.
 
### Contact Image
- I added the class "cs-bg-picture" to the nunjucks template, it was already styled but unused here, the version deployed on Netlify has it too.

### Visible Text
- I added the classes "menu-icon" and "visually-hidden".
- I changed the selector in the root.less file from #navigation span to #navigation menu-icon to prevent .visually-hidden from getting the pseudo elements that make the "hamburger menu".
- I hid the element with the visually-hidden class with the recommended practices

## Testing?
- I manually tested using Chrome Dev Tools default devices, as well as their default breakpoints

## Screenshots 

### Header

Mobile

Before
![image](https://user-images.githubusercontent.com/98567681/225114027-2e007fbf-5bd7-4868-a08f-025530e1a2d1.png)
After
![image](https://user-images.githubusercontent.com/98567681/225114174-f9757103-2be9-4f1d-88a1-ab56760e0915.png)

- Desktop 

Before
![image](https://user-images.githubusercontent.com/98567681/225114350-44a1618f-0ab4-4e57-9f36-aacb9caadef9.png)
After
![image](https://user-images.githubusercontent.com/98567681/225114477-4a9b6f32-0098-4e56-aa32-c5398cb76f1a.png)

### Contact Image

- Mobile

Before
![image](https://user-images.githubusercontent.com/98567681/225126112-4dfbcd20-df80-442e-9cc9-b37ab08c811d.png)
After
![image](https://user-images.githubusercontent.com/98567681/225126147-d4ca6590-88d3-4e67-a6a6-8e66e4752a90.png)


- Desktop

Before
![image](https://user-images.githubusercontent.com/98567681/225125988-3e120ac9-8d44-4b68-a62c-2f41018318e1.png)
After
![image](https://user-images.githubusercontent.com/98567681/225126016-9fd3a186-b897-4f2a-a621-636b95e47aaa.png)


### Visible Text
- Mobile

Before
![image](https://user-images.githubusercontent.com/98567681/225125509-7bec7ed6-d47f-4e44-a500-661353111483.png)
After
![image](https://user-images.githubusercontent.com/98567681/225125584-87a54d86-888d-4031-853f-96c8051d0d85.png)