### PR TITLE
remove deprecated/non-functional code in 11ty config file

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,12 +59,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('./src/_redirects');
   eleventyConfig.addPassthroughCopy({ './src/robots.txt': '/robots.txt' });
 
-  // open on npm start and watch CSS files for changes - doesn't trigger 11ty rebuild
-  eleventyConfig.setBrowserSyncConfig({
-    open: true,
-    files: './public/css/**/*.css',
-  });
-
   // allows the {% image %} shortcode to be used for optimised iamges (in webp if possible)
   eleventyConfig.addNunjucksAsyncShortcode('image', imageShortcode);
 


### PR DESCRIPTION
According to [the docs](https://www.11ty.dev/docs/dev-server/#setbrowsersyncconfig), the `setBrowserSyncConfig` function is a no-op in Eleventy v2.x.

This pull request removes the section of code that references this deprecated function.

Fixes #9